### PR TITLE
Added an option to deactive the default autoloot

### DIFF
--- a/Addon.lua
+++ b/Addon.lua
@@ -40,6 +40,7 @@ local defaults = {
 	EnhanceSounds = true,
 	ActivateOnEquip = true,
 	ActivateOnMouseover = true,
+	ActivateAutoloot = true,
 	MouseoverTimeout = 10,
 	CVars = {
 		Sound_EnableAllSound = 1,
@@ -168,8 +169,11 @@ function GoFish:EnableFishingMode()
 	autoInteract = GetCVar("autointeract")
 	SetCVar("autointeract", 0)
 
-	autoLoot = GetCVar("autoLootDefault")
-	SetCVar("autoLootDefault", 1)
+	if GoFishDB.ActivateAutoloot then
+		--print("Autoloot is enabled");
+		autoLoot = GetCVar("autoLootDefault")
+		SetCVar("autoLootDefault", 1)
+	end
 
 	isFishing = true
 	print("|cff00ddbaGoFish:|r", L["Quick fishing {ON}"])
@@ -183,8 +187,10 @@ function GoFish:DisableFishingMode()
 	SetCVar("autointeract", autoInteract)
 	autoInteract = nil
 
-	SetCVar("autoLootDefault", autoLoot)
-	autoLoot = nil
+	if GoFishDB.ActivateAutoloot then
+		SetCVar("autoLootDefault", autoLoot)
+		autoLoot = nil
+	end
 
 	autoStopTime = nil
 	print("|cff00ddbaGoFish:|r", L["Quick fishing {OFF}"])

--- a/Options.lua
+++ b/Options.lua
@@ -58,8 +58,18 @@ Options:SetScript("OnShow", function()
 		end
 	end)
 
+	local ActivateAutoloot = CreateFrame("CheckButton", "$parentActivateAutoloot", Options, "InterfaceOptionsCheckButtonTemplate")
+	ActivateAutoloot:SetPoint("TOPLEFT", ActivateOnEquip, "BOTTOMLEFT", 0, -12)
+	ActivateAutoloot.Text:SetText(L["Activate autoloot"])
+	ActivateAutoloot.tooltipText = L["Activate or deactivate autoloot when on fishing mode. Usefull if you already have a autoloot addon."]
+	ActivateAutoloot:SetScript("OnClick", function(this)
+		local checked = not not this:GetChecked()
+		GoFishDB.ActivateAutoloot = checked
+		ReloadUI()
+	end)
+
 	local EnhanceSounds = CreateFrame("CheckButton", "$parentEnhanceSounds", Options, "InterfaceOptionsCheckButtonTemplate")
-	EnhanceSounds:SetPoint("TOPLEFT", ActivateOnEquip, "BOTTOMLEFT", 0, -12)
+	EnhanceSounds:SetPoint("TOPLEFT", ActivateAutoloot, "BOTTOMLEFT", 0, -12)
 	EnhanceSounds.Text:SetText(L["Enhance sound effects while fishing"])
 	EnhanceSounds.tooltipText = L["To better hear the fishing bobber splash, turn Sounds up, and Music and Ambience down. Your normal sound levels are restored after fishing."]
 	EnhanceSounds:SetScript("OnClick", function(this)
@@ -155,6 +165,7 @@ Options:SetScript("OnShow", function()
 	function Options:refresh()
 		ActivateOnMouseover:SetChecked(GoFishDB.ActivateOnMouseover)
 		ActivateOnEquip:SetChecked(GoFishDB.ActivateOnEquip)
+		ActivateAutoloot:SetChecked(GoFishDB.ActivateAutoloot)
 
 		EnhanceSounds:SetChecked(GoFishDB.EnhanceSounds)
 		MasterVolume:SetEnabled(GoFishDB.EnhanceSounds)

--- a/Options.lua
+++ b/Options.lua
@@ -65,7 +65,6 @@ Options:SetScript("OnShow", function()
 	ActivateAutoloot:SetScript("OnClick", function(this)
 		local checked = not not this:GetChecked()
 		GoFishDB.ActivateAutoloot = checked
-		ReloadUI()
 	end)
 
 	local EnhanceSounds = CreateFrame("CheckButton", "$parentEnhanceSounds", Options, "InterfaceOptionsCheckButtonTemplate")


### PR DESCRIPTION
Added an option to deactivate the default autoloot for those who already
have an autoloot addon.

The GoFish default autoloot is enabled by default to keep the addon
default behaviours.
